### PR TITLE
fix: color picker bug & testInvite with correct regex

### DIFF
--- a/components/dashboard/cards/DashboardCardsConfig.tsx
+++ b/components/dashboard/cards/DashboardCardsConfig.tsx
@@ -14,6 +14,7 @@ import { useQuery, useQueryClient } from 'react-query';
 import CardInfo from './CardInfo';
 import { GradientTemplates } from '@/lib/constants/GradientTemplates';
 import { CardGradients } from '@/lib/types/CardGradients';
+import { testInvite } from '@/lib/types/testInvite';
 
 type CardBody = Omit<CardData, 'rules' | 'channel'> & { rulesField: { rule: string }[] } & { channelID: string };
 export default function DashboardCardsConfig({ id }: { id: string }) {
@@ -140,7 +141,7 @@ export default function DashboardCardsConfig({ id }: { id: string }) {
         <div className={"flex flex-col h-fit flex-1 justify-center items-center max-md:gap-2"}>
         <label className={"text-xl font-montserrat"}>Invite URL</label>
         <Controller name={`invite_url`} control={control} render={({ field }) => {
-                    const tested = /^https:\/\/discord\.gg\/(invite\/|)\w+$/.test(field.value || '');
+                    const tested = testInvite(field.value ?? '');
                     return  <span className={`w-fit ${tested ? 'text-green-500' : (field.value?.length || 0) > 10 ? 'text-red-500' : ''}`}><TextBox className={"w-56 text-sm"} Icon={BsDiscord} maxLength={60} value={field.value} onChange={(e) => field.onChange(e.currentTarget.value)}/></span>
         } }/>
         </div>

--- a/components/input/ColorPicker.tsx
+++ b/components/input/ColorPicker.tsx
@@ -27,11 +27,11 @@ export default function ColorPicker({ value, onChange, string, md }: ColorPicker
     <span className={"border text-white rounded-2xl w-fit p-1 hover-gradient transition-all hover:text-black hover:border-black text-lg cursor-pointer"} onClick={() => setExpandedColor(!expandedColor)}>
             <div className={"h-6 w-12 rounded-2xl shadow-2xl border border-white"} style={{ backgroundColor: value ? `#${value}` : "black" }}></div>
             </span> Set Color
-            <HexColorInput aria-valuenow={parseInt(value, 16)} color={value} className={"text-md rounded-xl  px-1"} onChange={(newColor) => onChange(!string ? parseInt(newColor.replace("#", ""), 16) : newColor.replace("#", ""))}/>
+            <HexColorInput aria-valuenow={parseInt(value, 16)} color={value} className={"text-md rounded-xl px-1"} onChange={(newColor) => onChange(!string ? parseInt(newColor.replace("#", ""), 16) : newColor.replace("#", ""))}/>
         
     </span>
     {expandedColor && 
-    <HexColorPicker aria-valuenow={parseInt(value, 16)} className={`md:absolute md:z-30 flex-none touch-none animate-colorPicker`} onChange={(newColor) => onChange(!string ? parseInt(newColor.replace("#", ""), 16) : newColor.replace("#", ""))}/> }
+    <HexColorPicker aria-valuenow={parseInt(value, 16)} className={`md:absolute z-30 flex-none touch-none animate-colorPicker`} onChange={(newColor) => onChange(!string ? parseInt(newColor.replace("#", ""), 16) : newColor.replace("#", ""))}/> }
     </span>
    
     </span> ;

--- a/lib/types/testInvite.ts
+++ b/lib/types/testInvite.ts
@@ -1,0 +1,3 @@
+export function testInvite(url: string) {
+    return /(https?:\/\/|http?:\/\/)?(www.)?(discord.(gg|io|me|li)|discordapp.com\/invite|discord.com\/invite)\/[^\s\/]+?(?=\b)/.test(url); 
+}


### PR DESCRIPTION
* fix an issue with the color picker not having a z-30 on md layouts
* fix an issue with incorrect regex for discord invites (outlined in #31 )
