### PR TITLE
fix(embed): inline emoji in embed values

### DIFF
--- a/components/ui/messages/discord-message.tsx
+++ b/components/ui/messages/discord-message.tsx
@@ -161,7 +161,14 @@ export function DiscordMessage({
                                         ),
                                 }}
                                 components={{
-                                    Twemoji,
+                                    Twemoji: ({ children }) => (
+                                        <Twemoji
+                                            serverID={serverData?.serverID}
+                                            className='inline'
+                                        >
+                                            {children?.toString()}
+                                        </Twemoji>
+                                    ),
                                 }}
                             />
                         </span>


### PR DESCRIPTION
Emojis in embed values were not inlined, creating a weird effect where it would make a new line. Also, I dont think server emojis worked either. This is now fixed.